### PR TITLE
fix(log): create log folder

### DIFF
--- a/bin/init.rb
+++ b/bin/init.rb
@@ -88,7 +88,7 @@ puts 'Updating custom collections'
 puts
 
 custom_collections.each do |collection|
-  puts "updating postions for custom collection #{collection}"
+  puts "updating postions for custom collection #{collection.id}"
 
   result = UpdateProductsOrder.new(
     collection: collection,


### PR DESCRIPTION
I commit a log folder for the script to not raise when executed the first time.
I also fixed the custom collections logging to log the ID of the collection instead of the ruby object.